### PR TITLE
Destroy kref_debug on failure in drbd_create_device.

### DIFF
--- a/drbd/drbd_main.c
+++ b/drbd/drbd_main.c
@@ -3740,6 +3740,7 @@ out_no_disk:
 	blk_cleanup_queue(q);
 out_no_q:
 	kref_put(&resource->kref, drbd_destroy_resource);
+	kref_debug_destroy(&device->kref_debug);
 	kfree(device);
 	return err;
 }


### PR DESCRIPTION
If we fail with ERR_NOMEM, drbd_create_device will be called
again and crash if we do not clean up kref_debug.

Small thing but I just ran into this issue by instrumenting
the code.

Best Wishes, 

- Johannes